### PR TITLE
Possible TypeError when type hinting the Pool rejected callable with a RequestException

### DIFF
--- a/src/Image/ImagesLoaderToTemp.php
+++ b/src/Image/ImagesLoaderToTemp.php
@@ -117,7 +117,7 @@ final class ImagesLoaderToTemp implements ImagesLoaderInterface
             'fulfilled' => function (Response $response, $imageName) use (&$imagesForDownload) {
                 $imagesForDownload[$imageName]['is_lacking'] = false;
             },
-            'rejected' => function (RequestException $reason, $imageName) use (&$imagesForDownload) {
+            'rejected' => function (\Throwable $reason, $imageName) use (&$imagesForDownload) {
                 $imagesForDownload[$imageName]['is_lacking'] = true;
             }
         ]);

--- a/src/Image/ImagesLoaderToTemp.php
+++ b/src/Image/ImagesLoaderToTemp.php
@@ -117,6 +117,7 @@ final class ImagesLoaderToTemp implements ImagesLoaderInterface
             'fulfilled' => function (Response $response, $imageName) use (&$imagesForDownload) {
                 $imagesForDownload[$imageName]['is_lacking'] = false;
             },
+            // 'rejected' => function (RequestException $reason, $imageName) use (&$imagesForDownload) {
             'rejected' => function (\Throwable $reason, $imageName) use (&$imagesForDownload) {
                 $imagesForDownload[$imageName]['is_lacking'] = true;
             }


### PR DESCRIPTION
Possible TypeError when type hinting the Pool rejected callable with a RequestException

Guzzle version(s) affected: 7.4.2

Description
The documentation for using a GuzzleHttp\Pool suggests type hinting the rejected callable with a \GuzzleHttp\Exception\RequestException
https://docs.guzzlephp.org/en/stable/quickstart.html#concurrent-requests

This can lead to a TypeError since it is possible to receive a \GuzzleHttp\Exception\ConnectException at this point as well.